### PR TITLE
Specify QT version when running qtmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Compiling on Debian/Ubuntu:
  - Install QT5 (libqt5-dev, or from source from qt-project.org)
  - Install ffmpeg libraries: apt-get install libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
  - Run: qmake BBQScreenClient2.linux.pro
+   - You may have to specify the QT version, e.g. `qmake -qt=qt5 BBQScreenClient2.linux.pro`
  - Run: make
  - The final binary will be built at ./Linux/BBQScreenClient2
 


### PR DESCRIPTION
On Ubuntu 14.04, I had to pass the flag `-qt=qt5` to qmake.

This fixes the following error message:

`qmake: could not exec '/usr/lib/x86_64-linux-gnu/qt4/bin/qmake': No such file or directory`
